### PR TITLE
feat: use relay config

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   },
   "dependencies": {
     "fast-glob": "~3.0.3",
-    "graphql": "14"
+    "graphql": "14",
+    "relay-config": "^5.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { Runner, DotGraphQLParser } from 'relay-compiler'
 import RelayLanguagePluginJavaScript from 'relay-compiler/lib/RelayLanguagePluginJavaScript'
 import type { PluginInterface } from 'relay-compiler/lib/RelayLanguagePluginInterface'
 import RelaySourceModuleParser from 'relay-compiler/lib/RelaySourceModuleParser'
+import RelayConfig from 'relay-config'
 
 import fs from 'fs'
 import path from 'path'
@@ -55,9 +56,29 @@ class RelayCompilerWebpackPlugin {
 
   options: RelayCompilerWebpackPluginOptions
 
-  constructor (options: RelayCompilerWebpackPluginOptions) {
-    if (!options) {
-      throw new Error('You must provide options to RelayCompilerWebpackPlugin.')
+  constructor (pluginOptions: RelayCompilerWebpackPluginOptions = {}) {
+    let {
+      src,
+      schema,
+      artifactDirectory,
+      language: languagePlugin,
+      extensions: configExtensions,
+      ...config
+    } = RelayConfig.loadConfig() || {}
+
+    if (typeof languagePlugin === 'string') {
+      // $FlowFixMe
+      languagePlugin = require(languagePlugin)
+    }
+
+    const options = {
+      src,
+      schema,
+      languagePlugin,
+      artifactDirectory,
+      extensions: configExtensions,
+      ...pluginOptions,
+      config: { ...config, ...pluginOptions.config }
     }
 
     if (!options.schema) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2049,7 +2049,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cosmiconfig@^5.2.0:
+cosmiconfig@^5.0.5, cosmiconfig@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -5538,6 +5538,13 @@ relay-compiler@^5.0.0:
     relay-runtime "5.0.0"
     signedsource "^1.0.0"
     yargs "^9.0.0"
+
+relay-config@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/relay-config/-/relay-config-5.0.0.tgz#42fea9b7c70357b008816c19df939c18995ab02d"
+  integrity sha512-EdVcVau4k92DgPrqm/UUSsRLp/33Wj+wU5fN5Yx6MsDx/h4ul1RWoA4n1XdC3cNAWKHs68V6N54iQ4TREw9d7g==
+  dependencies:
+    cosmiconfig "^5.0.5"
 
 relay-runtime@5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Not sure if you're open to this, but I thought i'd throw it up now to see. This leaverages the some logic relay-compiler does to find and use a config file (`relay.config.js`) a wholly undocumented but supported feature