### PR TITLE
Moved graphql to be a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
   },
   "peerDependencies": {
     "relay-compiler": "^8.0.0",
-    "webpack": ">=3.0.0"
+    "webpack": ">=3.0.0",
+    "graphql": "^14.5.8"
   },
   "dependencies": {
     "fast-glob": "^3.1.0",
-    "graphql": "^14.5.8",
     "tapable": "^1.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This prevents multiple conflicting graphql package versions being installed and should fix #56
